### PR TITLE
Re-order prettier plugins

### DIFF
--- a/02-prettier/.prettierrc.json
+++ b/02-prettier/.prettierrc.json
@@ -5,8 +5,8 @@
   "singleQuote": false,
   "jsxSingleQuote": false,
   "plugins": [
-    "prettier-plugin-tailwindcss",
-    "@ianvs/prettier-plugin-sort-imports"
+    "@ianvs/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
   ],
   "importOrder": [
     "^(react/(.*)$)|^(react$)",


### PR DESCRIPTION
As per the [documentation](https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#compatibility-with-other-prettier-plugins)

The `prettier-plugin-tailwindcss` plugin *is* compatible with other prettier plugins but must be loaded last, this caused issues on my local setup with WebStorm.